### PR TITLE
Use https when fetching miniconda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Thomas Wiecki <thomas.wiecki@gmail.com>
 RUN apt-get update && apt-get upgrade -y && apt-get install -y wget libsm6 libxrender1 libfontconfig1
 
 # Install miniconda
-RUN wget --quiet http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh && \
+RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh && \
     bash Miniconda-latest-Linux-x86_64.sh -b -p /opt/miniconda && \
     rm Miniconda-latest-Linux-x86_64.sh
 ENV PATH /opt/miniconda/bin:$PATH


### PR DESCRIPTION
Recently repo.continuum.io enabled SSL/TLS for their site (ref: https://github.com/ContinuumIO/docker-images/pull/7). This just sets the image to use that https endpoint.
