### PR TITLE
Fix build error ImportError: libgthread-2.0.so.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM jupyter/jupyterhub
 
 MAINTAINER Thomas Wiecki <thomas.wiecki@gmail.com>
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y wget libsm6 libxrender1 libfontconfig1
+RUN apt-get update && apt-get upgrade -y && apt-get install -y wget libsm6 libxrender1 libfontconfig1 libglib2.0-0
 
 # Install miniconda
 RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \


### PR DESCRIPTION
Step 10 : RUN python -c "import numpy, scipy, pandas, matplotlib, matplotlib.pyplot, sklearn, seaborn, statsmodels, theano"
 ---> Running in c4cbd41cc586
/opt/miniconda3/lib/python3.5/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.  
  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')  
/opt/miniconda3/lib/python3.5/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.  
  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')  
Traceback (most recent call last):  
  File "<string>", line 1, in <module>  
  File "/opt/miniconda3/lib/python3.5/site-packages/matplotlib/pyplot.py", line 114, in <module>  
    _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()  
  File "/opt/miniconda3/lib/python3.5/site-packages/matplotlib/backends/__init__.py", line 32, in pylab_setup  
    globals(),locals(),[backend_name],0)  
  File "/opt/miniconda3/lib/python3.5/site-packages/matplotlib/backends/backend_qt4agg.py", line 18, in <module>  
    from .backend_qt5agg import FigureCanvasQTAggBase as _FigureCanvasQTAggBase  
  File "/opt/miniconda3/lib/python3.5/site-packages/matplotlib/backends/backend_qt5agg.py", line 15, in <module>  
    from .backend_qt5 import QtCore  
  File "/opt/miniconda3/lib/python3.5/site-packages/matplotlib/backends/backend_qt5.py", line 31, in <module>  
    from .qt_compat import QtCore, QtGui, QtWidgets, _getSaveFileName, __version__  
  File "/opt/miniconda3/lib/python3.5/site-packages/matplotlib/backends/qt_compat.py", line 124, in <module>  
    from PyQt4 import QtCore, QtGui  
ImportError: libgthread-2.0.so.0: cannot open shared object file: No such file or directory  
The command '/bin/sh -c python -c "import numpy, scipy, pandas, matplotlib, matplotlib.pyplot, sklearn, seaborn, statsmodels, theano"' returned a non-zero code: 1
